### PR TITLE
Add Nevermined subgraph for Base Sepolia

### DIFF
--- a/subgraphs/nevermined-base-sepolia/.gitignore
+++ b/subgraphs/nevermined-base-sepolia/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+generated/
+build/
+yarn.lock
+package-lock.json

--- a/subgraphs/nevermined-base-sepolia/README.md
+++ b/subgraphs/nevermined-base-sepolia/README.md
@@ -1,0 +1,649 @@
+# Nevermined Subgraph — Base Sepolia
+
+A [The Graph](https://thegraph.com/) subgraph that indexes all Nevermined protocol activity on Base Sepolia. Deployed on [Goldsky](https://goldsky.com/) for free testnet indexing.
+
+## GraphQL Endpoint
+
+```
+https://api.goldsky.com/api/public/project_cmmdxa29pqd7301x809tn06ng/subgraphs/nevermined-base-sepolia/1.0.0/gn
+```
+
+No authentication required. Open the URL in a browser for an interactive GraphQL playground.
+
+## What It Indexes
+
+| Data Source | Contract | What It Tracks |
+|-------------|----------|----------------|
+| **NFT1155Credits** | `0xb2F9bB43F768E0D4ADCa49CE708acbE577bC2d64` | Credit mints, burns (redemptions), transfers |
+| **NFT1155ExpirableCreditsV2** | `0xF7Fe16718a779010E48859fb1c7Eae9fd540872F` | Same events for expirable credits |
+| **AgreementsStore** | `0x1B8B04BbF240bfB15f12368352a1397E3882660C` | Agreement creation, condition fulfillment |
+| **USDC** | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | Payments to PaymentsVault |
+
+### On-Chain Event Flow
+
+When a user purchases credits (crypto or Stripe/fiat):
+
+1. **AgreementRegistered** — a new agreement is created in `AgreementsStore`
+2. **ConditionUpdated** (x2) — payment settlement + credit transfer conditions are fulfilled
+3. **TransferSingle** (mint) — credits are minted to the buyer (from = `0x0`)
+
+When credits are redeemed (used to call an AI agent):
+
+4. **TransferSingle/TransferBatch** (burn) — credits are burned (to = `0x0`)
+
+When paying with USDC:
+
+5. **ERC20 Transfer** — USDC moves from buyer to `PaymentsVault` (`0x47A72d7094c4c5B0566E159579DBD79220A0EA24`)
+
+## Entities
+
+| Entity | Description |
+|--------|-------------|
+| `CreditTransfer` | Every credit mint, burn, or transfer event |
+| `DailyPlanStats` | Aggregated daily stats per plan (mints, burns, amounts) |
+| `USDCPayment` | USDC transfers to the PaymentsVault |
+| `Agreement` | Registered agreements (purchases) |
+| `ConditionUpdate` | Condition state changes within agreements |
+| `ProtocolStats` | Global cumulative protocol metrics |
+
+## Schema Reference
+
+### CreditTransfer
+
+Emitted every time credits are minted, burned, or transferred between wallets. This is the core entity for tracking credit activity.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `Bytes!` | Unique ID derived from transaction hash + log index |
+| `type` | `String!` | `"mint"` (from = zero address), `"burn"` (to = zero address), or `"transfer"` (wallet to wallet) |
+| `operator` | `Bytes!` | Address that initiated the transaction (may differ from `from` when using account abstraction / session keys) |
+| `from` | `Bytes!` | Sender address. `0x000...000` for mints |
+| `to` | `Bytes!` | Receiver address. `0x000...000` for burns |
+| `planId` | `BigInt!` | The Nevermined plan ID (ERC1155 token ID). Identifies which AI agent/service plan the credits belong to |
+| `amount` | `BigInt!` | Number of credits minted, burned, or transferred |
+| `blockNumber` | `BigInt!` | Block number on Base Sepolia |
+| `blockTimestamp` | `BigInt!` | Unix timestamp of the block |
+| `transactionHash` | `Bytes!` | Transaction hash on Base Sepolia |
+
+### DailyPlanStats
+
+Pre-aggregated daily statistics per plan. Useful for building time-series charts without client-side aggregation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String!` | Composite key: `"YYYY-MM-DD-{planId}"` |
+| `date` | `String!` | Date string in `YYYY-MM-DD` format |
+| `planId` | `BigInt!` | The Nevermined plan ID |
+| `mintCount` | `Int!` | Number of mint transactions that day |
+| `burnCount` | `Int!` | Number of burn (redemption) transactions that day |
+| `transferCount` | `Int!` | Number of wallet-to-wallet transfers that day |
+| `creditsMinted` | `BigInt!` | Total credits minted that day for this plan |
+| `creditsBurned` | `BigInt!` | Total credits burned (redeemed) that day for this plan |
+| `creditsTransferred` | `BigInt!` | Total credits transferred between wallets that day |
+
+### USDCPayment
+
+Tracks USDC (ERC20) transfers sent to the Nevermined `PaymentsVault` contract. Only transfers **to** the vault are indexed — other USDC activity is ignored.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `Bytes!` | Unique ID derived from transaction hash + log index |
+| `from` | `Bytes!` | Payer wallet address |
+| `amount` | `BigDecimal!` | USDC amount in human-readable form (divided by 10^6) |
+| `rawAmount` | `BigInt!` | Raw USDC amount in smallest unit (6 decimals). `1000000` = 1 USDC |
+| `blockNumber` | `BigInt!` | Block number on Base Sepolia |
+| `blockTimestamp` | `BigInt!` | Unix timestamp of the block |
+| `transactionHash` | `Bytes!` | Transaction hash on Base Sepolia |
+
+### Agreement
+
+Created when a user purchases a plan (crypto or fiat/Stripe). Each agreement contains conditions that must be fulfilled to complete the purchase and deliver credits.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `Bytes!` | The `agreementId` (bytes32 hash) — unique identifier for this purchase agreement |
+| `creator` | `Bytes!` | Address that created the agreement (usually the buyer or the Nevermined node on behalf of the buyer) |
+| `conditions` | `[ConditionUpdate!]!` | Derived relation — all condition state changes for this agreement |
+| `blockNumber` | `BigInt!` | Block number on Base Sepolia |
+| `blockTimestamp` | `BigInt!` | Unix timestamp of the block |
+| `transactionHash` | `Bytes!` | Transaction hash on Base Sepolia |
+
+### ConditionUpdate
+
+Tracks condition state changes within an agreement. A typical purchase has 2 conditions: a payment/settlement condition and a credit transfer condition. Both must be fulfilled for the purchase to complete.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `Bytes!` | Unique ID derived from transaction hash + log index |
+| `agreement` | `Agreement!` | Reference to the parent agreement |
+| `conditionId` | `Bytes!` | The condition's unique identifier (bytes32 hash) |
+| `state` | `Int!` | Condition state: `0` = Uninitialized, `1` = Unfulfilled, `2` = Fulfilled, `3` = Aborted |
+| `blockNumber` | `BigInt!` | Block number on Base Sepolia |
+| `blockTimestamp` | `BigInt!` | Unix timestamp of the block |
+| `transactionHash` | `Bytes!` | Transaction hash on Base Sepolia |
+
+### ProtocolStats
+
+A single global entity (`id: "global"`) with cumulative protocol-wide metrics. Updated on every relevant event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String!` | Always `"global"` — there is only one instance |
+| `totalMints` | `Int!` | Total number of credit mint events |
+| `totalBurns` | `Int!` | Total number of credit burn (redemption) events |
+| `totalCreditsMinted` | `BigInt!` | Cumulative credits minted across all plans |
+| `totalCreditsBurned` | `BigInt!` | Cumulative credits burned across all plans |
+| `totalUSDCVolume` | `BigDecimal!` | Cumulative USDC paid to the PaymentsVault (human-readable, e.g. `"1.50"`) |
+| `totalAgreements` | `Int!` | Total number of agreements registered |
+| `totalFulfilledConditions` | `Int!` | Total number of conditions that reached `Fulfilled` state |
+
+## Query Examples
+
+### Global Protocol Stats
+
+Get a high-level overview of all Nevermined activity:
+
+```graphql
+{
+  protocolStats(id: "global") {
+    totalMints
+    totalBurns
+    totalCreditsMinted
+    totalCreditsBurned
+    totalUSDCVolume
+    totalAgreements
+    totalFulfilledConditions
+  }
+}
+```
+
+### Credit Mints (Purchases)
+
+All credit purchases, most recent first:
+
+```graphql
+{
+  creditTransfers(
+    where: { type: "mint" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 20
+  ) {
+    to
+    planId
+    amount
+    blockTimestamp
+    transactionHash
+  }
+}
+```
+
+### Credit Burns (Redemptions)
+
+All credit redemptions when agents are called:
+
+```graphql
+{
+  creditTransfers(
+    where: { type: "burn" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 20
+  ) {
+    from
+    planId
+    amount
+    blockTimestamp
+    transactionHash
+  }
+}
+```
+
+### Credit Transfers Between Users
+
+Credits transferred between wallets (not mints or burns):
+
+```graphql
+{
+  creditTransfers(
+    where: { type: "transfer" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 20
+  ) {
+    from
+    to
+    planId
+    amount
+    blockTimestamp
+    transactionHash
+  }
+}
+```
+
+### USDC Payments
+
+All USDC payments to the Nevermined PaymentsVault:
+
+```graphql
+{
+  usdcpayments(
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 20
+  ) {
+    from
+    amount
+    rawAmount
+    blockTimestamp
+    transactionHash
+  }
+}
+```
+
+### Large USDC Payments (Above a Threshold)
+
+Filter payments above 1 USDC:
+
+```graphql
+{
+  usdcpayments(
+    where: { rawAmount_gt: "1000000" }
+    orderBy: amount
+    orderDirection: desc
+  ) {
+    from
+    amount
+    blockTimestamp
+    transactionHash
+  }
+}
+```
+
+### Daily Stats Per Plan
+
+Aggregated daily activity broken down by plan:
+
+```graphql
+{
+  dailyPlanStats(
+    orderBy: date
+    orderDirection: desc
+    first: 30
+  ) {
+    date
+    planId
+    mintCount
+    burnCount
+    transferCount
+    creditsMinted
+    creditsBurned
+    creditsTransferred
+  }
+}
+```
+
+### Daily Stats for a Specific Plan
+
+Filter to a single plan ID:
+
+```graphql
+{
+  dailyPlanStats(
+    where: { planId: "12345" }
+    orderBy: date
+    orderDirection: desc
+    first: 30
+  ) {
+    date
+    mintCount
+    burnCount
+    creditsMinted
+    creditsBurned
+  }
+}
+```
+
+### Agreements (Purchases)
+
+Recent agreements with their condition states:
+
+```graphql
+{
+  agreements(
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 10
+  ) {
+    id
+    creator
+    blockTimestamp
+    transactionHash
+    conditions {
+      conditionId
+      state
+      blockTimestamp
+    }
+  }
+}
+```
+
+Condition states: `0` = Uninitialized, `1` = Unfulfilled, `2` = Fulfilled, `3` = Aborted.
+
+### Agreements by Creator
+
+Filter agreements by a specific wallet:
+
+```graphql
+{
+  agreements(
+    where: { creator: "0xfb340ff496d1c34a1a5d45a97821d6a704696755" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+  ) {
+    id
+    blockTimestamp
+    transactionHash
+    conditions {
+      state
+    }
+  }
+}
+```
+
+### Fulfilled Conditions Only
+
+Find all successfully completed conditions:
+
+```graphql
+{
+  conditionUpdates(
+    where: { state: 2 }
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 20
+  ) {
+    agreement {
+      id
+      creator
+    }
+    conditionId
+    blockTimestamp
+    transactionHash
+  }
+}
+```
+
+### All Activity for a Specific Address
+
+Combine credit burns and mints for a wallet:
+
+```graphql
+{
+  burns: creditTransfers(
+    where: { from: "0xfb340ff496d1c34a1a5d45a97821d6a704696755", type: "burn" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+  ) {
+    planId
+    amount
+    blockTimestamp
+  }
+  mints: creditTransfers(
+    where: { to: "0xfb340ff496d1c34a1a5d45a97821d6a704696755", type: "mint" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+  ) {
+    planId
+    amount
+    blockTimestamp
+  }
+  payments: usdcpayments(
+    where: { from: "0xfb340ff496d1c34a1a5d45a97821d6a704696755" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+  ) {
+    amount
+    blockTimestamp
+  }
+}
+```
+
+### Pagination
+
+Use `skip` and `first` for paginated results:
+
+```graphql
+{
+  creditTransfers(
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 10
+    skip: 20
+  ) {
+    type
+    planId
+    amount
+    blockTimestamp
+  }
+}
+```
+
+### Time Range Filter
+
+Filter events within a time window (Unix timestamps):
+
+```graphql
+{
+  creditTransfers(
+    where: {
+      blockTimestamp_gte: "1763100000"
+      blockTimestamp_lte: "1763200000"
+    }
+    orderBy: blockTimestamp
+    orderDirection: desc
+  ) {
+    type
+    from
+    to
+    planId
+    amount
+    blockTimestamp
+  }
+}
+```
+
+### Count Events by Type
+
+Get totals for mints vs burns:
+
+```graphql
+{
+  mints: creditTransfers(where: { type: "mint" }) { id }
+  burns: creditTransfers(where: { type: "burn" }) { id }
+  transfers: creditTransfers(where: { type: "transfer" }) { id }
+}
+```
+
+> Note: The Graph limits results to 1000 per query. For exact counts, use `protocolStats`.
+
+## Querying from Code
+
+### curl
+
+```bash
+curl -s -X POST \
+  'https://api.goldsky.com/api/public/project_cmmdxa29pqd7301x809tn06ng/subgraphs/nevermined-base-sepolia/1.0.0/gn' \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ protocolStats(id:\"global\") { totalMints totalBurns totalUSDCVolume } }"}'
+```
+
+### TypeScript / JavaScript
+
+```typescript
+const SUBGRAPH_URL =
+  'https://api.goldsky.com/api/public/project_cmmdxa29pqd7301x809tn06ng/subgraphs/nevermined-base-sepolia/1.0.0/gn'
+
+async function query(graphql: string) {
+  const res = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: graphql }),
+  })
+  const { data } = await res.json()
+  return data
+}
+
+// Example: get recent burns
+const data = await query(`{
+  creditTransfers(where: { type: "burn" }, orderBy: blockTimestamp, orderDirection: desc, first: 10) {
+    planId
+    amount
+    from
+    blockTimestamp
+  }
+}`)
+```
+
+### Python
+
+```python
+import requests
+
+SUBGRAPH_URL = "https://api.goldsky.com/api/public/project_cmmdxa29pqd7301x809tn06ng/subgraphs/nevermined-base-sepolia/1.0.0/gn"
+
+def query(graphql: str):
+    response = requests.post(SUBGRAPH_URL, json={"query": graphql})
+    return response.json()["data"]
+
+# Example: get protocol stats
+data = query('{ protocolStats(id: "global") { totalMints totalBurns totalUSDCVolume } }')
+print(data)
+```
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- npm
+
+### Setup
+
+```bash
+cd subgraphs/nevermined-base-sepolia
+npm install
+```
+
+### Build
+
+```bash
+npm run codegen    # Generate types from schema + ABIs
+npm run build      # Compile to WASM
+```
+
+### Deploy to Goldsky
+
+[Goldsky](https://goldsky.com/) is the recommended deployment target because it supports Base Sepolia (The Graph's decentralized network only supports mainnets).
+
+#### 1. Create a Goldsky Account
+
+Sign up at https://app.goldsky.com (free tier includes 500K rows).
+
+#### 2. Install the Goldsky CLI
+
+```bash
+curl https://goldsky.com | sh
+```
+
+Or download directly:
+```bash
+curl -fsSL https://cli.goldsky.com/latest/linux/goldsky -o /usr/local/bin/goldsky
+chmod +x /usr/local/bin/goldsky
+```
+
+#### 3. Authenticate
+
+Get your API key from https://app.goldsky.com/dashboard/settings, then:
+
+```bash
+goldsky login
+# Paste your API key when prompted
+```
+
+Or non-interactively:
+```bash
+goldsky login --token YOUR_API_KEY
+```
+
+#### 4. Build and Deploy
+
+```bash
+cd subgraphs/nevermined-base-sepolia
+npm install
+npm run codegen
+npm run build
+npm run deploy:goldsky
+```
+
+This deploys as `nevermined-base-sepolia/1.0.0`. The version is set in `package.json` under the `deploy:goldsky` script.
+
+#### 5. Verify Deployment
+
+```bash
+goldsky subgraph list
+```
+
+You should see:
+```
+* nevermined-base-sepolia/1.0.0
+    Status: healthy (Active)
+    Chain: base-sepolia
+```
+
+#### 6. Monitor Sync Progress
+
+```bash
+goldsky subgraph list
+```
+
+The `Synced` percentage shows how far the indexer has caught up to the chain head. The subgraph starts indexing from block `33681969` (contract deployment block), not from genesis.
+
+#### Updating the Subgraph
+
+To deploy a new version after making changes:
+
+```bash
+npm run codegen
+npm run build
+goldsky subgraph deploy nevermined-base-sepolia/1.1.0 --path .
+```
+
+#### Deleting a Deployment
+
+```bash
+goldsky subgraph delete nevermined-base-sepolia/1.0.0
+```
+
+### Deploy to a Self-Hosted Graph Node
+
+If you prefer running your own infrastructure:
+
+```bash
+# Requires a running Graph Node connected to a Base Sepolia RPC
+npm run deploy:local
+```
+
+## Contract Addresses (Base Sepolia v1.3.2)
+
+| Contract | Address |
+|----------|---------|
+| NFT1155Credits | `0xb2F9bB43F768E0D4ADCa49CE708acbE577bC2d64` |
+| NFT1155ExpirableCredits | `0x6de675a697f9131D061F265fAf88E26158f4FfA2` |
+| NFT1155ExpirableCreditsV2 | `0xF7Fe16718a779010E48859fb1c7Eae9fd540872F` |
+| AgreementsStore | `0x1B8B04BbF240bfB15f12368352a1397E3882660C` |
+| PaymentsVault | `0x47A72d7094c4c5B0566E159579DBD79220A0EA24` |
+| USDC | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| FiatPaymentTemplate | `0x386eF80de6Afe51838672Ec6c08081C3f6A2C2d8` |
+| FixedPaymentTemplate | `0x32037D176558Eb02f6980eFA14bde14B0C61d059` |
+| PayAsYouGoTemplate | `0x5e852077b30099106Aa65B4d329FFF9b5C9a8e7C` |

--- a/subgraphs/nevermined-base-sepolia/README.md
+++ b/subgraphs/nevermined-base-sepolia/README.md
@@ -409,6 +409,73 @@ Combine credit burns and mints for a wallet:
 }
 ```
 
+### Identifying Fiat/Stripe Payments
+
+Stripe (fiat) payments and crypto payments both create on-chain agreements, but they follow different patterns:
+
+- **Fiat/Stripe purchases** go through `FiatPaymentTemplate` and create agreements with **3 conditions**: FiatSettlementCondition + DistributePaymentsCondition + TransferCreditsCondition
+- **Crypto (USDC) purchases** go through `FixedPaymentTemplate` and create agreements with **2 conditions**: LockPaymentCondition + TransferCreditsCondition
+
+You can use this to filter fiat vs crypto purchases:
+
+**Fiat/Stripe agreements (3 conditions):**
+
+```graphql
+{
+  agreements(
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 20
+  ) {
+    id
+    creator
+    blockTimestamp
+    transactionHash
+    conditions {
+      conditionId
+      state
+    }
+  }
+}
+```
+
+Then filter client-side: agreements with `conditions.length == 3` are fiat/Stripe, those with `conditions.length == 2` are crypto.
+
+**Combined view — fiat purchases with their associated credit mints:**
+
+Since the agreement and the credit mint happen in the same transaction, you can join them by `transactionHash`:
+
+```graphql
+{
+  fiatAgreements: agreements(
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 10
+  ) {
+    id
+    creator
+    blockTimestamp
+    transactionHash
+    conditions { state }
+  }
+  creditMints: creditTransfers(
+    where: { type: "mint" }
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 50
+  ) {
+    to
+    planId
+    amount
+    transactionHash
+  }
+}
+```
+
+Match entries where `fiatAgreements[].transactionHash == creditMints[].transactionHash` and the agreement has 3 conditions — those are Stripe-funded credit purchases.
+
+> **Note:** The Stripe charge itself is off-chain and not visible in the subgraph. What you see on-chain is the settlement: the agreement registration, condition fulfillment, and credit minting that happens after the Stripe charge succeeds.
+
 ### Pagination
 
 Use `skip` and `first` for paginated results:

--- a/subgraphs/nevermined-base-sepolia/abis/AgreementsStore.json
+++ b/subgraphs/nevermined-base-sepolia/abis/AgreementsStore.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "AgreementRegistered",
+    "inputs": [
+      { "name": "agreementId", "type": "bytes32", "indexed": true },
+      { "name": "creator", "type": "address", "indexed": true }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "ConditionUpdated",
+    "inputs": [
+      { "name": "agreementId", "type": "bytes32", "indexed": true },
+      { "name": "conditionId", "type": "bytes32", "indexed": true },
+      { "name": "state", "type": "uint8", "indexed": false }
+    ]
+  }
+]

--- a/subgraphs/nevermined-base-sepolia/abis/ERC20.json
+++ b/subgraphs/nevermined-base-sepolia/abis/ERC20.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "Transfer",
+    "inputs": [
+      { "name": "from", "type": "address", "indexed": true },
+      { "name": "to", "type": "address", "indexed": true },
+      { "name": "value", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "Approval",
+    "inputs": [
+      { "name": "owner", "type": "address", "indexed": true },
+      { "name": "spender", "type": "address", "indexed": true },
+      { "name": "value", "type": "uint256", "indexed": false }
+    ]
+  }
+]

--- a/subgraphs/nevermined-base-sepolia/abis/NFT1155Credits.json
+++ b/subgraphs/nevermined-base-sepolia/abis/NFT1155Credits.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "TransferSingle",
+    "inputs": [
+      { "name": "operator", "type": "address", "indexed": true },
+      { "name": "from", "type": "address", "indexed": true },
+      { "name": "to", "type": "address", "indexed": true },
+      { "name": "id", "type": "uint256", "indexed": false },
+      { "name": "value", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "TransferBatch",
+    "inputs": [
+      { "name": "operator", "type": "address", "indexed": true },
+      { "name": "from", "type": "address", "indexed": true },
+      { "name": "to", "type": "address", "indexed": true },
+      { "name": "ids", "type": "uint256[]", "indexed": false },
+      { "name": "values", "type": "uint256[]", "indexed": false }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "BurnerAllowed",
+    "inputs": [
+      { "name": "owner", "type": "address", "indexed": false },
+      { "name": "burner", "type": "address", "indexed": false },
+      { "name": "planId", "type": "uint256", "indexed": false }
+    ]
+  }
+]

--- a/subgraphs/nevermined-base-sepolia/package.json
+++ b/subgraphs/nevermined-base-sepolia/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nevermined-base-sepolia-subgraph",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "codegen": "graph codegen",
+    "build": "graph build",
+    "deploy:goldsky": "goldsky subgraph deploy nevermined-base-sepolia/1.0.0 --path .",
+    "deploy:local": "graph create --node http://localhost:8020/ nevermined-base-sepolia && graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 nevermined-base-sepolia"
+  },
+  "dependencies": {
+    "@graphprotocol/graph-cli": "^0.93.2",
+    "@graphprotocol/graph-ts": "^0.35.1"
+  }
+}

--- a/subgraphs/nevermined-base-sepolia/schema.graphql
+++ b/subgraphs/nevermined-base-sepolia/schema.graphql
@@ -1,0 +1,70 @@
+# Credit mints and burns via NFT1155Credits
+type CreditTransfer @entity {
+  id: Bytes!
+  type: String!             # "mint", "burn", or "transfer"
+  operator: Bytes!
+  from: Bytes!
+  to: Bytes!
+  planId: BigInt!
+  amount: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# Aggregated daily stats per plan
+type DailyPlanStats @entity {
+  id: String!               # "YYYY-MM-DD-{planId}"
+  date: String!
+  planId: BigInt!
+  mintCount: Int!
+  burnCount: Int!
+  transferCount: Int!
+  creditsMinted: BigInt!
+  creditsBurned: BigInt!
+  creditsTransferred: BigInt!
+}
+
+# USDC payments to PaymentsVault
+type USDCPayment @entity {
+  id: Bytes!
+  from: Bytes!
+  amount: BigDecimal!       # USDC amount (6 decimals converted)
+  rawAmount: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# Agreements registered (covers both crypto and fiat purchases)
+type Agreement @entity {
+  id: Bytes!                # agreementId
+  creator: Bytes!
+  conditions: [ConditionUpdate!]! @derivedFrom(field: "agreement")
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# Condition state changes within agreements
+type ConditionUpdate @entity {
+  id: Bytes!
+  agreement: Agreement!
+  conditionId: Bytes!
+  state: Int!               # 0=Uninitialized, 1=Unfulfilled, 2=Fulfilled, 3=Aborted
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# Global protocol stats
+type ProtocolStats @entity {
+  id: String!               # "global"
+  totalMints: Int!
+  totalBurns: Int!
+  totalCreditsMinted: BigInt!
+  totalCreditsBurned: BigInt!
+  totalUSDCVolume: BigDecimal!
+  totalAgreements: Int!
+  totalFulfilledConditions: Int!
+}

--- a/subgraphs/nevermined-base-sepolia/src/agreements.ts
+++ b/subgraphs/nevermined-base-sepolia/src/agreements.ts
@@ -1,0 +1,54 @@
+import { BigInt, Bytes } from "@graphprotocol/graph-ts"
+import {
+  AgreementRegistered,
+  ConditionUpdated as ConditionUpdatedEvent,
+} from "../generated/AgreementsStore/AgreementsStore"
+import { Agreement, ConditionUpdate, ProtocolStats } from "../generated/schema"
+
+function getOrCreateProtocolStats(): ProtocolStats {
+  let stats = ProtocolStats.load("global")
+  if (stats == null) {
+    stats = new ProtocolStats("global")
+    stats.totalMints = 0
+    stats.totalBurns = 0
+    stats.totalCreditsMinted = BigInt.zero()
+    stats.totalCreditsBurned = BigInt.zero()
+    stats.totalUSDCVolume = BigInt.zero().toBigDecimal()
+    stats.totalAgreements = 0
+    stats.totalFulfilledConditions = 0
+  }
+  return stats
+}
+
+export function handleAgreementRegistered(event: AgreementRegistered): void {
+  let entity = new Agreement(event.params.agreementId)
+  entity.creator = event.params.creator
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  entity.save()
+
+  let stats = getOrCreateProtocolStats()
+  stats.totalAgreements += 1
+  stats.save()
+}
+
+export function handleConditionUpdated(event: ConditionUpdatedEvent): void {
+  let entity = new ConditionUpdate(
+    event.transaction.hash.concatI32(event.logIndex.toI32())
+  )
+  entity.agreement = event.params.agreementId
+  entity.conditionId = event.params.conditionId
+  entity.state = event.params.state
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  entity.save()
+
+  // State 2 = Fulfilled
+  if (event.params.state == 2) {
+    let stats = getOrCreateProtocolStats()
+    stats.totalFulfilledConditions += 1
+    stats.save()
+  }
+}

--- a/subgraphs/nevermined-base-sepolia/src/credits.ts
+++ b/subgraphs/nevermined-base-sepolia/src/credits.ts
@@ -1,0 +1,162 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
+import {
+  TransferSingle,
+  TransferBatch,
+} from "../generated/NFT1155Credits/NFT1155Credits"
+import { CreditTransfer, DailyPlanStats, ProtocolStats } from "../generated/schema"
+
+const ZERO_ADDRESS = Address.fromString("0x0000000000000000000000000000000000000000")
+const SECONDS_PER_DAY = 86400
+
+function getTransferType(from: Address, to: Address): string {
+  if (from == ZERO_ADDRESS) return "mint"
+  if (to == ZERO_ADDRESS) return "burn"
+  return "transfer"
+}
+
+function dayIdFromTimestamp(timestamp: BigInt): string {
+  let dayTimestamp = timestamp.toI32() / SECONDS_PER_DAY
+  let year = 1970
+  let days = dayTimestamp
+
+  // Approximate year calculation
+  while (true) {
+    let daysInYear = 365
+    if (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) daysInYear = 366
+    if (days < daysInYear) break
+    days -= daysInYear
+    year++
+  }
+
+  // Approximate month/day
+  let monthDays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  if (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) monthDays[1] = 29
+  let month = 1
+  for (let i = 0; i < 12; i++) {
+    if (days < monthDays[i]) break
+    days -= monthDays[i]
+    month++
+  }
+  let day = days + 1
+
+  let y = year.toString()
+  let m = month < 10 ? "0" + month.toString() : month.toString()
+  let d = day < 10 ? "0" + day.toString() : day.toString()
+  return y + "-" + m + "-" + d
+}
+
+function getOrCreateProtocolStats(): ProtocolStats {
+  let stats = ProtocolStats.load("global")
+  if (stats == null) {
+    stats = new ProtocolStats("global")
+    stats.totalMints = 0
+    stats.totalBurns = 0
+    stats.totalCreditsMinted = BigInt.zero()
+    stats.totalCreditsBurned = BigInt.zero()
+    stats.totalUSDCVolume = BigInt.zero().toBigDecimal()
+    stats.totalAgreements = 0
+    stats.totalFulfilledConditions = 0
+  }
+  return stats
+}
+
+function updateDailyStats(
+  timestamp: BigInt,
+  planId: BigInt,
+  transferType: string,
+  amount: BigInt
+): void {
+  let dateStr = dayIdFromTimestamp(timestamp)
+  let id = dateStr + "-" + planId.toString()
+  let daily = DailyPlanStats.load(id)
+  if (daily == null) {
+    daily = new DailyPlanStats(id)
+    daily.date = dateStr
+    daily.planId = planId
+    daily.mintCount = 0
+    daily.burnCount = 0
+    daily.transferCount = 0
+    daily.creditsMinted = BigInt.zero()
+    daily.creditsBurned = BigInt.zero()
+    daily.creditsTransferred = BigInt.zero()
+  }
+
+  if (transferType == "mint") {
+    daily.mintCount += 1
+    daily.creditsMinted = daily.creditsMinted.plus(amount)
+  } else if (transferType == "burn") {
+    daily.burnCount += 1
+    daily.creditsBurned = daily.creditsBurned.plus(amount)
+  } else {
+    daily.transferCount += 1
+    daily.creditsTransferred = daily.creditsTransferred.plus(amount)
+  }
+
+  daily.save()
+}
+
+export function handleTransferSingle(event: TransferSingle): void {
+  let transferType = getTransferType(event.params.from, event.params.to)
+
+  let entity = new CreditTransfer(
+    event.transaction.hash.concatI32(event.logIndex.toI32())
+  )
+  entity.type = transferType
+  entity.operator = event.params.operator
+  entity.from = event.params.from
+  entity.to = event.params.to
+  entity.planId = event.params.id
+  entity.amount = event.params.value
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  entity.save()
+
+  // Update daily stats
+  updateDailyStats(event.block.timestamp, event.params.id, transferType, event.params.value)
+
+  // Update protocol stats
+  let stats = getOrCreateProtocolStats()
+  if (transferType == "mint") {
+    stats.totalMints += 1
+    stats.totalCreditsMinted = stats.totalCreditsMinted.plus(event.params.value)
+  } else if (transferType == "burn") {
+    stats.totalBurns += 1
+    stats.totalCreditsBurned = stats.totalCreditsBurned.plus(event.params.value)
+  }
+  stats.save()
+}
+
+export function handleTransferBatch(event: TransferBatch): void {
+  let transferType = getTransferType(event.params.from, event.params.to)
+  let ids = event.params.ids
+  let values = event.params.values
+
+  for (let i = 0; i < ids.length; i++) {
+    let entity = new CreditTransfer(
+      event.transaction.hash.concatI32(event.logIndex.toI32() * 1000 + i)
+    )
+    entity.type = transferType
+    entity.operator = event.params.operator
+    entity.from = event.params.from
+    entity.to = event.params.to
+    entity.planId = ids[i]
+    entity.amount = values[i]
+    entity.blockNumber = event.block.number
+    entity.blockTimestamp = event.block.timestamp
+    entity.transactionHash = event.transaction.hash
+    entity.save()
+
+    updateDailyStats(event.block.timestamp, ids[i], transferType, values[i])
+
+    let stats = getOrCreateProtocolStats()
+    if (transferType == "mint") {
+      stats.totalMints += 1
+      stats.totalCreditsMinted = stats.totalCreditsMinted.plus(values[i])
+    } else if (transferType == "burn") {
+      stats.totalBurns += 1
+      stats.totalCreditsBurned = stats.totalCreditsBurned.plus(values[i])
+    }
+    stats.save()
+  }
+}

--- a/subgraphs/nevermined-base-sepolia/src/usdc.ts
+++ b/subgraphs/nevermined-base-sepolia/src/usdc.ts
@@ -1,0 +1,43 @@
+import { Address, BigDecimal, BigInt, Bytes } from "@graphprotocol/graph-ts"
+import { Transfer } from "../generated/USDC/ERC20"
+import { USDCPayment, ProtocolStats } from "../generated/schema"
+
+const PAYMENTS_VAULT = Address.fromString("0x47A72d7094c4c5B0566E159579DBD79220A0EA24")
+const USDC_DECIMALS = BigDecimal.fromString("1000000") // 6 decimals
+
+function getOrCreateProtocolStats(): ProtocolStats {
+  let stats = ProtocolStats.load("global")
+  if (stats == null) {
+    stats = new ProtocolStats("global")
+    stats.totalMints = 0
+    stats.totalBurns = 0
+    stats.totalCreditsMinted = BigInt.zero()
+    stats.totalCreditsBurned = BigInt.zero()
+    stats.totalUSDCVolume = BigInt.zero().toBigDecimal()
+    stats.totalAgreements = 0
+    stats.totalFulfilledConditions = 0
+  }
+  return stats
+}
+
+export function handleUSDCTransfer(event: Transfer): void {
+  // Only index transfers TO the PaymentsVault
+  if (event.params.to != PAYMENTS_VAULT) return
+
+  let usdcAmount = event.params.value.toBigDecimal().div(USDC_DECIMALS)
+
+  let entity = new USDCPayment(
+    event.transaction.hash.concatI32(event.logIndex.toI32())
+  )
+  entity.from = event.params.from
+  entity.amount = usdcAmount
+  entity.rawAmount = event.params.value
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  entity.save()
+
+  let stats = getOrCreateProtocolStats()
+  stats.totalUSDCVolume = stats.totalUSDCVolume.plus(usdcAmount)
+  stats.save()
+}

--- a/subgraphs/nevermined-base-sepolia/subgraph.yaml
+++ b/subgraphs/nevermined-base-sepolia/subgraph.yaml
@@ -1,0 +1,106 @@
+specVersion: 1.0.0
+indexerHints:
+  prune: auto
+schema:
+  file: ./schema.graphql
+dataSources:
+  # NFT1155Credits - credit mints, burns, transfers
+  - kind: ethereum
+    name: NFT1155Credits
+    network: base-sepolia
+    source:
+      address: "0xb2F9bB43F768E0D4ADCa49CE708acbE577bC2d64"
+      abi: NFT1155Credits
+      startBlock: 33681969
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - CreditTransfer
+        - DailyPlanStats
+        - ProtocolStats
+      abis:
+        - name: NFT1155Credits
+          file: ./abis/NFT1155Credits.json
+      eventHandlers:
+        - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleTransferSingle
+        - event: TransferBatch(indexed address,indexed address,indexed address,uint256[],uint256[])
+          handler: handleTransferBatch
+      file: ./src/credits.ts
+
+  # NFT1155ExpirableCreditsV2 - same events, different contract
+  - kind: ethereum
+    name: NFT1155ExpirableCreditsV2
+    network: base-sepolia
+    source:
+      address: "0xF7Fe16718a779010E48859fb1c7Eae9fd540872F"
+      abi: NFT1155Credits
+      startBlock: 33681969
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - CreditTransfer
+        - DailyPlanStats
+        - ProtocolStats
+      abis:
+        - name: NFT1155Credits
+          file: ./abis/NFT1155Credits.json
+      eventHandlers:
+        - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleTransferSingle
+        - event: TransferBatch(indexed address,indexed address,indexed address,uint256[],uint256[])
+          handler: handleTransferBatch
+      file: ./src/credits.ts
+
+  # AgreementsStore - agreement registration and condition fulfillment
+  - kind: ethereum
+    name: AgreementsStore
+    network: base-sepolia
+    source:
+      address: "0x1B8B04BbF240bfB15f12368352a1397E3882660C"
+      abi: AgreementsStore
+      startBlock: 33681969
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Agreement
+        - ConditionUpdate
+        - ProtocolStats
+      abis:
+        - name: AgreementsStore
+          file: ./abis/AgreementsStore.json
+      eventHandlers:
+        - event: AgreementRegistered(indexed bytes32,indexed address)
+          handler: handleAgreementRegistered
+        - event: ConditionUpdated(indexed bytes32,indexed bytes32,uint8)
+          handler: handleConditionUpdated
+      file: ./src/agreements.ts
+
+  # USDC on Base Sepolia - payments to PaymentsVault
+  - kind: ethereum
+    name: USDC
+    network: base-sepolia
+    source:
+      address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+      abi: ERC20
+      startBlock: 33681969
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - USDCPayment
+        - ProtocolStats
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleUSDCTransfer
+      file: ./src/usdc.ts


### PR DESCRIPTION
## Summary

- Adds a Graph Protocol subgraph that indexes all Nevermined protocol activity on **Base Sepolia**
- Deployed on **Goldsky** (free testnet indexing — Dune and The Graph decentralized network don't support Base Sepolia)
- Already live and returning data at the GraphQL endpoint

### What it indexes

| Data Source | Events |
|-------------|--------|
| **NFT1155Credits** + **NFT1155ExpirableCreditsV2** | Credit mints, burns (redemptions), transfers |
| **AgreementsStore** | Agreement registration, condition fulfillment (covers both crypto and Stripe/fiat purchases) |
| **USDC** | Payments to PaymentsVault |

### Entities

- `CreditTransfer` — every mint/burn/transfer with plan ID and amount
- `DailyPlanStats` — pre-aggregated daily stats per plan
- `USDCPayment` — USDC payments to the vault
- `Agreement` / `ConditionUpdate` — purchase agreements and their fulfillment
- `ProtocolStats` — global cumulative metrics

### Live endpoint

```
https://api.goldsky.com/api/public/project_cmmdxa29pqd7301x809tn06ng/subgraphs/nevermined-base-sepolia/1.0.0/gn
```

### README includes

- Full schema reference with field descriptions
- 15+ GraphQL query examples (stats, mints, burns, USDC, agreements, filtering, pagination, time ranges)
- Code examples for curl, TypeScript, and Python
- Step-by-step Goldsky deployment guide

## Test plan

- [x] `npm run codegen` — types generated successfully
- [x] `npm run build` — compiles to WASM
- [x] Deployed to Goldsky — status: healthy, actively syncing
- [x] Verified queries return real Base Sepolia data (53 mints, 45 burns, 46 agreements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)